### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ uv run install.py
 
 Then open Claude or Cursor and you should see the MCP tool `usolver` available in the tool list.
 
+<a href="https://glama.ai/mcp/servers/@sdiehl/usolver">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sdiehl/usolver/badge" alt="USolver MCP server" />
+</a>
+
 ## Examples
 
 To run the individual solver examples. You can invoke the individual examples. Below are example using the solvers, and each module contains a docstring which can be used to prompt the language model to solve the problem.


### PR DESCRIPTION
This PR adds a badge for the [USolver](https://glama.ai/mcp/servers/@sdiehl/usolver) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sdiehl/usolver">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sdiehl/usolver/badge" alt="USolver MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.